### PR TITLE
Small change to the gitlab CI file

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,9 +20,9 @@ build:
   script:
     - $(aws ecr get-login --no-include-email --region us-east-1)
     - make docker-build
-    - docker tag $CI_PROJECT_NAME:$CI_COMMIT_SHA $REPOSITORY_URL/$CI_PROJECT_NAME:$CI_COMMIT_SHA
-    - docker tag $CI_PROJECT_NAME:$CI_COMMIT_SHA $REPOSITORY_URL/$CI_PROJECT_NAME:latest
-    - docker tag $CI_PROJECT_NAME:$CI_COMMIT_SHA $DOCKER_ORG/$CI_PROJECT_NAME:latest
+    - docker tag $CI_PROJECT_NAME $REPOSITORY_URL/$CI_PROJECT_NAME:$CI_COMMIT_SHA
+    - docker tag $CI_PROJECT_NAME $REPOSITORY_URL/$CI_PROJECT_NAME:latest
+    - docker tag $CI_PROJECT_NAME $DOCKER_ORG/$CI_PROJECT_NAME:latest
     - docker push $REPOSITORY_URL/$CI_PROJECT_NAME:$CI_COMMIT_SHA
     - docker push $REPOSITORY_URL/$CI_PROJECT_NAME:latest
     - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,15 +18,15 @@ build:
     - apk add --no-cache curl jq python py-pip make
     - pip install awscli docker-compose
   script:
-    - $(aws ecr get-login --no-include-email --region us-east-1)
     - make docker-build
+    - docker tag $CI_PROJECT_NAME $DOCKER_ORG/$CI_PROJECT_NAME:latest
     - docker tag $CI_PROJECT_NAME $REPOSITORY_URL/$CI_PROJECT_NAME:$CI_COMMIT_SHA
     - docker tag $CI_PROJECT_NAME $REPOSITORY_URL/$CI_PROJECT_NAME:latest
-    - docker tag $CI_PROJECT_NAME $DOCKER_ORG/$CI_PROJECT_NAME:latest
-    - docker push $REPOSITORY_URL/$CI_PROJECT_NAME:$CI_COMMIT_SHA
-    - docker push $REPOSITORY_URL/$CI_PROJECT_NAME:latest
     - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
     - docker push $DOCKER_ORG/$CI_PROJECT_NAME:latest
+    - $(aws ecr get-login --no-include-email --region us-east-1)
+    - docker push $REPOSITORY_URL/$CI_PROJECT_NAME:$CI_COMMIT_SHA
+    - docker push $REPOSITORY_URL/$CI_PROJECT_NAME:latest
 
 deploy:
   stage: deploy
@@ -35,7 +35,7 @@ deploy:
     - mkdir -p $HOME/.kube
     - echo -n $KUBE_CONFIG | base64 -d > $HOME/.kube/config
   script:
-    - kubectl set image deployment/$CI_PROJECT_NAME $CI_PROJECT_NAME=$REPOSITORY_URL/$CI_PROJECT_NAME:$CI_COMMIT_SHA
+    - kubectl set image deployment/$CI_PROJECT_NAME $CI_PROJECT_NAME=$DOCKER_ORG/$CI_PROJECT_NAME:latest
 
 verify:
   stage: verify


### PR DESCRIPTION
This pull request is to fix an issue where it tries to tag a non-existent image. The `make docker-build` file creates an image tag called fdns-ms-object, but this is looking for a tag with the commit sha which doesn't exist.