### PR TITLE
Moving the gitlab file from default to a named file

### DIFF
--- a/.gitlab-aws.yml
+++ b/.gitlab-aws.yml
@@ -14,6 +14,8 @@ stages:
 
 build:
   stage: build
+  only:
+    - master
   before_script:
     - apk add --no-cache curl jq python py-pip make
     - pip install awscli docker-compose
@@ -31,6 +33,8 @@ build:
 deploy:
   stage: deploy
   image: roffe/kubectl
+  only:
+    - master
   before_script:
     - mkdir -p $HOME/.kube
     - echo -n $KUBE_CONFIG | base64 -d > $HOME/.kube/config
@@ -39,5 +43,7 @@ deploy:
 
 verify:
   stage: verify
+  only:
+    - master
   script:
     - wget -qO- $VERIFY_URL


### PR DESCRIPTION
This pull request moves the gitlab CI/CD file from being a default `.gitlab-ci.yml` file to a named file (a manual action taken by the repository admin). This also adds the labels for only running on the master branch.