### PR TITLE
Fixes based on Hackathon and internal discussions

### DIFF
--- a/src/main/java/gov/cdc/foundation/helper/MessageHelper.java
+++ b/src/main/java/gov/cdc/foundation/helper/MessageHelper.java
@@ -15,6 +15,8 @@ public class MessageHelper extends AbstractMessageHelper {
 	public static final String METHOD_GETOBJECT = "getObject";
 	public static final String METHOD_CREATEOBJECT = "createObject";
 	public static final String METHOD_CREATEOBJECTS = "createObjects";
+	public static final String METHOD_GETCOLLECTION = "getCollection";
+
 	public static final String METHOD_BULKIMPORT = "bulkImport";
 	public static final String METHOD_UPDATEOBJECT = "updateObject";
 	public static final String METHOD_DELETEOBJECT = "deleteObject";
@@ -42,5 +44,5 @@ public class MessageHelper extends AbstractMessageHelper {
 		log.put(MessageHelper.CONST_COLLECTION, collection);
 		return log;
 	}
-	
+
 }


### PR DESCRIPTION
This PR contains changes to improve the functionality and descriptions of the API routes/verbs.

- Adds a `GET` that retrieves all objects in a given collection.
- Updates the description for the Mongo Wrapper routes (aggregate/count/distinct/find) to make it more clear what those endpoints do.
- Clarified the distinction between the `search` and `find` routes and changed `search` to a `GET` since it uses query params instead of sending a payload.
- Fixed a bug with the bulk CSV import that prevented it from working.