### PR TITLE
Updated first-stage Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
 # build stage
 FROM maven:3-jdk-8 as builder
 RUN mkdir -p /usr/src/app
-COPY . /usr/src/app
+COPY pom.xml /usr/src/app
 WORKDIR /usr/src/app
+RUN mvn dependency:resolve
+COPY . /usr/src/app
 RUN mvn clean package
 
 # run stage


### PR DESCRIPTION
This change leverages Docker layer caching to dramatically speed up second-time and subsequent Docker builds. 

By copying only `pom.xml` and using Maven's dependency resolve (which only downloads dependencies and does nothing else), most dependencies are cached in a Docker layer. As long as `pom.xml` does not change, then this layer won't be rebuilt - it will instead be reused from previous builds' caches. 

The impact is that developers can now change source code without worrying that a Docker build will spend minutes downloading dependencies.