### PR TITLE
Updating documentation for docker hub

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,0 +1,59 @@
+# FDNS Object Microservice
+
+Foundation Services (FDNS) Object Microservice is the mutable layer of the data lake.
+
+## Getting Started
+
+To get started with the FDNS Object Microservice you can use either `docker stack deploy` or `docker-compose`:
+
+```yaml
+version: '3.1'
+services:
+  fluentd:
+    image: fluent/fluentd
+    ports:
+      - "24224:24224"
+  mongo:
+    image: mongo
+    ports:
+      - "27017:27017"
+  fdns-ms-object:
+    image: cdcgov/fdns-ms-object
+    ports:
+      - "8083:8083"
+    depends_on:
+      - fluentd
+      - mongo
+    environment:
+      OBJECT_PORT: 8083
+      OBJECT_MONGO_HOST: mongo
+      OBJECT_MONGO_PORT: 27017
+      OBJECT_FLUENTD_HOST: fluentd
+      OBJECT_FLUENTD_PORT: 24224
+
+```
+
+[![Try in PWD](https://raw.githubusercontent.com/play-with-docker/stacks/master/assets/images/button.png)](http://play-with-docker.com?stack=https://raw.githubusercontent.com/CDCgov/fdns-ms-object/master/stack.yml)
+
+## Source Code
+
+Please see [https://github.com/CDCgov/fdns-ms-object](https://github.com/CDCgov/fdns-ms-object) for the fdns-ms-object source repository.
+
+## Public Domain
+
+This repository constitutes a work of the United States Government and is not subject to domestic copyright protection under 17 USC § 105. This repository is in the public domain within the United States, and copyright and related rights in the work worldwide are waived through the [CC0 1.0 Universal public domain dedication](https://creativecommons.org/publicdomain/zero/1.0/). All contributions to this repository will be released under the CC0 dedication.
+
+## License
+
+The repository utilizes code licensed under the terms of the Apache Software License and therefore is licensed under ASL v2 or later.
+
+The container image in this repository is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the Apache Software License for more details.
+
+## Privacy
+
+This repository contains only non-sensitive, publicly available data and information. All material and community participation is covered by the Surveillance Platform [Disclaimer](https://github.com/CDCgov/template/blob/master/DISCLAIMER.md) and [Code of Conduct](https://github.com/CDCgov/template/blob/master/code-of-conduct.md).
+For more information about CDC's privacy policy, please visit [http://www.cdc.gov/privacy.html](http://www.cdc.gov/privacy.html).
+
+## Records
+
+This repository is not a source of government records, but is a copy to increase collaboration and collaborative potential. All government records will be published through the [CDC web site](http://www.cdc.gov).

--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
 [![Build Status](https://travis-ci.org/CDCgov/fdns-ms-object.svg?branch=master)](https://travis-ci.org/CDCgov/fdns-ms-object)
 
 # FDNS Object Microservice
+
 This repository contains the Object layer for the Data Lake. This is the mutable layer of the data lake.
 
 ## Running locally
+
 Please read the following instructions carefully for information on how to build, run and test this microservice in your local environment.
 
 ### Before you start
+
 You will need to have the following installed before getting up and running locally:
 
 - Docker, [Installation guides](https://docs.docker.com/install/)
@@ -17,7 +20,7 @@ You will need to have the following installed before getting up and running loca
 
 First you'll need to build the image, to do so just run the following command:
 
-```
+```sh
 make docker-build
 ```
 
@@ -25,7 +28,7 @@ make docker-build
 
 Now you'll be able to run the image, you can easily do so by running the following command:
 
-```
+```sh
 make docker-run
 ```
 
@@ -45,29 +48,29 @@ To access the Swagger documentation, just open the following URL in your browser
 
 First, you need to configure these environment variables using Docker or the STS Launch Configuration:
 
-* `OBJECT_MONGO_HOST`: This is the host for your MongoDB server
-* `OBJECT_MONGO_PORT`: This is the port for your MongoDB server
-* `OBJECT_MONGO_USER_DATABASE`: Contains where the user name and password are stored in MongoDB, by default it's `admin`
-* `OBJECT_MONGO_USERNAME`: The user name that you want to use to authenticate
-* `OBJECT_MONGO_PASSWORD`: The password that you want to use to authenticate
+- `OBJECT_MONGO_HOST`: This is the host for your MongoDB server
+- `OBJECT_MONGO_PORT`: This is the port for your MongoDB server
+- `OBJECT_MONGO_USER_DATABASE`: Contains where the user name and password are stored in MongoDB, by default it's `admin`
+- `OBJECT_MONGO_USERNAME`: The user name that you want to use to authenticate
+- `OBJECT_MONGO_PASSWORD`: The password that you want to use to authenticate
 
 Be sure, that you have properly configured your MongoDB server. If you use the `docker-compose.yml` file in this project, after starting Mongo, you need to:
 
-* Login to the MongoDB server (in this case, we connect to the `admin` database):
+Login to the MongoDB server (in this case, we connect to the `admin` database):
 
-```
+```sh
 docker exec -it fdns-ms-object_mongo_1 mongo admin
 ```
 
-* And create the user:
+And create the user:
 
-```
+```sh
 db.createUser({ user: 'admin', pwd: 'admin', roles: [ { role: "userAdminAnyDatabase", db: "admin" } ] });
 ```
 
-* Exit the console, by typing:
+Exit the console, by typing:
 
-```
+```sh
 exit
 ```
 
@@ -79,23 +82,24 @@ __Scopes__: This application uses the following scope: `object.database.collecti
 
 Please see the following environment variables for configuring with your OAuth 2 provider:
 
-* `OAUTH2_ACCESS_TOKEN_URI`: This is the introspection URL of your provider, ex: `https://hydra:4444/oauth2/introspect`
-* `OAUTH2_PROTECTED_URIS`: This is a path for which routes are to be restricted, ex: `/api/1.0/**`
-* `OAUTH2_CLIENT_ID`: This is your OAuth 2 client id with the provider
-* `OAUTH2_CLIENT_SECRET`: This is your OAuth 2 client secret with the provider
-* `SSL_VERIFYING_DISABLE`: This is an option to disable SSL verification, you can disable this when testing locally but this should be set to `false` for all production systems
+- `OAUTH2_ACCESS_TOKEN_URI`: This is the introspection URL of your provider, ex: `https://hydra:4444/oauth2/introspect`
+- `OAUTH2_PROTECTED_URIS`: This is a path for which routes are to be restricted, ex: `/api/1.0/**`
+- `OAUTH2_CLIENT_ID`: This is your OAuth 2 client id with the provider
+- `OAUTH2_CLIENT_SECRET`: This is your OAuth 2 client secret with the provider
+- `SSL_VERIFYING_DISABLE`: This is an option to disable SSL verification, you can disable this when testing locally but this should be set to `false` for all production systems
 
 ### Miscellaneous Configurations
 
 Here are other various configurations and their purposes:
 
-* `OBJECT_PORT`: This is a configurable port the application is set to run on
-* `OBJECT_FLUENTD_HOST`: This is the host of your [Fluentd](https://www.fluentd.org/)
-* `OBJECT_FLUENTD_PORT`: This is the port of your [Fluentd](https://www.fluentd.org/)
-* `OBJECT_PROXY_HOSTNAME`: This is the hostname of your environment for use with Swagger UI, ex: `api.my.org`
-* `OBJECT_IMMUTABLE`: This is a `;` separated list of collections which are immutable collections
+- `OBJECT_PORT`: This is a configurable port the application is set to run on
+- `OBJECT_FLUENTD_HOST`: This is the host of your [Fluentd](https://www.fluentd.org/)
+- `OBJECT_FLUENTD_PORT`: This is the port of your [Fluentd](https://www.fluentd.org/)
+- `OBJECT_PROXY_HOSTNAME`: This is the hostname of your environment for use with Swagger UI, ex: `api.my.org`
+- `OBJECT_IMMUTABLE`: This is a `;` separated list of collections which are immutable collections
   
 ## Public Domain
+
 This repository constitutes a work of the United States Government and is not
 subject to domestic copyright protection under 17 USC § 105. This repository is in
 the public domain within the United States, and copyright and related rights in
@@ -105,6 +109,7 @@ submitting a pull request you are agreeing to comply with this waiver of
 copyright interest.
 
 ## License
+
 The repository utilizes code licensed under the terms of the Apache Software
 License and therefore is licensed under ASL v2 or later.
 
@@ -121,8 +126,8 @@ program. If not, see http://www.apache.org/licenses/LICENSE-2.0.html
 
 The source code forked from other open source projects will inherit its license.
 
-
 ## Privacy
+
 This repository contains only non-sensitive, publicly available data and
 information. All material and community participation is covered by the
 Surveillance Platform [Disclaimer](https://github.com/CDCgov/template/blob/master/DISCLAIMER.md)
@@ -130,6 +135,7 @@ and [Code of Conduct](https://github.com/CDCgov/template/blob/master/code-of-con
 For more information about CDC's privacy policy, please visit [http://www.cdc.gov/privacy.html](http://www.cdc.gov/privacy.html).
 
 ## Contributing
+
 Anyone is encouraged to contribute to the repository by [forking](https://help.github.com/articles/fork-a-repo)
 and submitting a pull request. (If you are new to GitHub, you might start with a
 [basic tutorial](https://help.github.com/articles/set-up-git).) By contributing
@@ -143,11 +149,13 @@ CDC including this GitHub page are subject to the [Presidential Records Act](htt
 and may be archived. Learn more at [http://www.cdc.gov/other/privacy.html](http://www.cdc.gov/other/privacy.html).
 
 ## Records
+
 This repository is not a source of government records, but is a copy to increase
 collaboration and collaborative potential. All government records will be
 published through the [CDC web site](http://www.cdc.gov).
 
 ## Notices
+
 Please refer to [CDC's Template Repository](https://github.com/CDCgov/template)
 for more information about [contributing to this repository](https://github.com/CDCgov/template/blob/master/CONTRIBUTING.md),
 [public domain notices and disclaimers](https://github.com/CDCgov/template/blob/master/DISCLAIMER.md),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.1'
 services:
   mongo:
     image: mongo

--- a/stack.yml
+++ b/stack.yml
@@ -1,0 +1,23 @@
+version: '3.1'
+services:
+  fluentd:
+    image: fluent/fluentd
+    ports:
+      - "24224:24224"
+  mongo:
+    image: mongo
+    ports:
+      - "27017:27017"
+  fdns-ms-object:
+    image: cdcgov/fdns-ms-object
+    ports:
+      - "8083:8083"
+    depends_on:
+      - fluentd
+      - mongo
+    environment:
+      OBJECT_PORT: 8083
+      OBJECT_MONGO_HOST: mongo
+      OBJECT_MONGO_PORT: 27017
+      OBJECT_FLUENTD_HOST: fluentd
+      OBJECT_FLUENTD_PORT: 24224


### PR DESCRIPTION
This pull request updates the README with small fixes for markdown (lines after headers are suggested, etc.). 

This also adds a suggested documentation for Docker Hub and adds a `stack.yml` to be used with http://play-with-docker.com/