### PR TITLE
Updating the OAuth 2.0 Scope Functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ exit
 
 This microservice is configurable to be secured with an OAuth 2 provider.
 
-__Scopes__: This application uses the following scope: `object.database.collection`
+__Scopes__: This application uses the following scope syntax: `fdns.object.{database}.{collection}.{create|read|update|delete}`. Example: `fdns.object.mydatabase.mycollection.read`
 
 Please see the following environment variables for configuring with your OAuth 2 provider:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,3 +8,7 @@ services:
     image: fluent/fluentd
     ports:
       - "24224:24224"
+  fdns-ms-stubbing:
+    image: cdcgov/fdns-ms-stubbing
+    ports:
+      - "3002:3002"

--- a/src/main/java/gov/cdc/foundation/controller/ObjectController.java
+++ b/src/main/java/gov/cdc/foundation/controller/ObjectController.java
@@ -95,7 +95,7 @@ public class ObjectController {
 	}
 
 
-	@PreAuthorize("!@authz.isSecured() or #oauth2.hasScope('object.'.concat(#db).concat('.').concat(#collection)) or (#db == 'settings')")
+	@PreAuthorize("!@authz.isSecured() or #oauth2.hasScope('fdns.object.'.concat(#db).concat('.').concat(#collection).concat('.read')) or (#db == 'settings')")
 	@RequestMapping(method = RequestMethod.GET, value = "/{db}/{collection}/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
 	@ApiOperation(value = "Get object", notes = "Get object")
 	@ApiResponses(value = {
@@ -145,7 +145,7 @@ public class ObjectController {
 		}
 	}
 
-	@PreAuthorize("!@authz.isSecured() or #oauth2.hasScope('object.'.concat(#db).concat('.').concat(#collection)) or (#db == 'settings')")
+	@PreAuthorize("!@authz.isSecured() or #oauth2.hasScope('fdns.object.'.concat(#db).concat('.').concat(#collection).concat('.create')) or (#db == 'settings')")
 	@RequestMapping(method = RequestMethod.POST, value = "/{db}/{collection}", produces = MediaType.APPLICATION_JSON_VALUE, consumes = MediaType.APPLICATION_JSON_VALUE)
 	@ApiOperation(value = "Create object", notes = "Create object")
 	@ApiResponses(value = {
@@ -176,7 +176,7 @@ public class ObjectController {
 		}
 	}
 
-	@PreAuthorize("!@authz.isSecured() or #oauth2.hasScope('object.'.concat(#db).concat('.').concat(#collection)) or (#db == 'settings')")
+	@PreAuthorize("!@authz.isSecured() or #oauth2.hasScope('fdns.object.'.concat(#db).concat('.').concat(#collection).concat('.read')) or (#db == 'settings')")
 	@RequestMapping(method = RequestMethod.GET, value = "/{db}/{collection}/", produces = MediaType.APPLICATION_JSON_VALUE)
 	@ApiOperation(value = "Get all objects in a collection", notes = "Get all objects in a collection")
 	@ApiResponses(value = {
@@ -217,7 +217,7 @@ public class ObjectController {
 		}
 	}
 
-	@PreAuthorize("!@authz.isSecured() or #oauth2.hasScope('object.'.concat(#db).concat('.').concat(#collection)) or (#db == 'settings')")
+	@PreAuthorize("!@authz.isSecured() or #oauth2.hasScope('fdns.object.'.concat(#db).concat('.').concat(#collection).concat('.create')) or (#db == 'settings')")
 	@RequestMapping(method = RequestMethod.POST, value = "/multi/{db}/{collection}", produces = MediaType.APPLICATION_JSON_VALUE, consumes = MediaType.APPLICATION_JSON_VALUE)
 	@ApiOperation(value = "Create a list of objects", notes = "Create a list of objects")
 	@ApiResponses(value = {
@@ -263,7 +263,7 @@ public class ObjectController {
 		}
 	}
 
-	@PreAuthorize("!@authz.isSecured() or #oauth2.hasScope('object.'.concat(#db).concat('.').concat(#collection))")
+	@PreAuthorize("!@authz.isSecured() or #oauth2.hasScope('fdns.object.'.concat(#db).concat('.').concat(#collection).concat('.create'))")
 	@RequestMapping(method = RequestMethod.POST, value = "/bulk/{db}/{collection}", produces = MediaType.APPLICATION_JSON_VALUE)
 	@ApiOperation(value = "Bulk import of objects from a CSV file", notes = "Bulk import of objects from a CSV file")
 	@ResponseBody
@@ -336,7 +336,7 @@ public class ObjectController {
 		}
 	}
 
-	@PreAuthorize("!@authz.isSecured() or #oauth2.hasScope('object.'.concat(#db).concat('.').concat(#collection)) or (#db == 'settings')")
+	@PreAuthorize("!@authz.isSecured() or #oauth2.hasScope('fdns.object.'.concat(#db).concat('.').concat(#collection).concat('.create')) or (#db == 'settings')")
 	@RequestMapping(method = RequestMethod.POST, value = "/{db}/{collection}/{id}", produces = MediaType.APPLICATION_JSON_VALUE, consumes = MediaType.APPLICATION_JSON_VALUE)
 	@ApiOperation(value = "Create object with id", notes = "Create object with id")
 	@ApiResponses(value = {
@@ -375,7 +375,7 @@ public class ObjectController {
 		}
 	}
 
-	@PreAuthorize("!@authz.isSecured() or #oauth2.hasScope('object.'.concat(#db).concat('.').concat(#collection)) or (#db == 'settings')")
+	@PreAuthorize("!@authz.isSecured() or #oauth2.hasScope('fdns.object.'.concat(#db).concat('.').concat(#collection).concat('.update')) or (#db == 'settings')")
 	@RequestMapping(method = RequestMethod.PUT, value = "/{db}/{collection}/{id}", produces = MediaType.APPLICATION_JSON_VALUE, consumes = MediaType.APPLICATION_JSON_VALUE)
 	@ApiOperation(value = "Update object", notes = "Update object")
 	@ApiResponses(value = {
@@ -432,7 +432,7 @@ public class ObjectController {
 		}
 	}
 
-	@PreAuthorize("!@authz.isSecured() or #oauth2.hasScope('object.'.concat(#db).concat('.').concat(#collection)) or (#db == 'settings')")
+	@PreAuthorize("!@authz.isSecured() or #oauth2.hasScope('fdns.object.'.concat(#db).concat('.').concat(#collection).concat('.delete')) or (#db == 'settings')")
 	@RequestMapping(method = RequestMethod.DELETE, value = "/{db}/{collection}/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
 	@ApiOperation(value = "Delete object", notes = "Delete object")
 	@ApiResponses(value = {
@@ -488,7 +488,7 @@ public class ObjectController {
 		}
 	}
 
-	@PreAuthorize("!@authz.isSecured() or #oauth2.hasScope('object.'.concat(#db).concat('.').concat(#collection))")
+	@PreAuthorize("!@authz.isSecured() or #oauth2.hasScope('fdns.object.'.concat(#db).concat('.').concat(#collection).concat('.delete'))")
 	@RequestMapping(method = RequestMethod.DELETE, value = "/{db}/{collection}", produces = MediaType.APPLICATION_JSON_VALUE)
 	@ApiOperation(value = "Delete collection", notes = "Delete collection")
 	@ApiResponses(value = {
@@ -533,7 +533,7 @@ public class ObjectController {
 		}
 	}
 
-	@PreAuthorize("!@authz.isSecured() or #oauth2.hasScope('object.'.concat(#db).concat('.').concat(#collection))")
+	@PreAuthorize("!@authz.isSecured() or #oauth2.hasScope('fdns.object.'.concat(#db).concat('.').concat(#collection).concat('.read'))")
 	@RequestMapping(method = RequestMethod.GET, value = "/{db}/{collection}/search", produces = MediaType.APPLICATION_JSON_VALUE)
 	@ApiOperation(value = "Search object(s) using query parameters", notes = "Search object(s) in a specific collection using URL parameters instead of POST payloads (as FIND does)")
 	@ApiResponses(value = {
@@ -574,7 +574,7 @@ public class ObjectController {
 		}
 	}
 
-	@PreAuthorize("!@authz.isSecured() or #oauth2.hasScope('object.'.concat(#db).concat('.').concat(#collection))")
+	@PreAuthorize("!@authz.isSecured() or #oauth2.hasScope('fdns.object.'.concat(#db).concat('.').concat(#collection).concat('.read'))")
 	@RequestMapping(method = RequestMethod.POST, value = "/{db}/{collection}/find", produces = MediaType.APPLICATION_JSON_VALUE, consumes = MediaType.APPLICATION_JSON_VALUE)
 	@ApiOperation(value = "Find object(s)", notes = "Uses MongoDB's find method to  object(s)")
 	@ApiResponses(value = {
@@ -646,7 +646,7 @@ public class ObjectController {
 		return json;
 	}
 
-	@PreAuthorize("!@authz.isSecured() or #oauth2.hasScope('object.'.concat(#db).concat('.').concat(#collection))")
+	@PreAuthorize("!@authz.isSecured() or #oauth2.hasScope('fdns.object.'.concat(#db).concat('.').concat(#collection).concat('.read'))")
 	@RequestMapping(method = RequestMethod.POST, value = "/{db}/{collection}/aggregate", produces = MediaType.APPLICATION_JSON_VALUE, consumes = MediaType.APPLICATION_JSON_VALUE)
 	@ApiOperation(value = "Mongo Aggregate", notes = "Uses MongoDB's Aggregate method to calculate aggregate values in a collection")
 	@ApiResponses(value = {
@@ -703,7 +703,7 @@ public class ObjectController {
 		}
 	}
 
-	@PreAuthorize("!@authz.isSecured() or #oauth2.hasScope('object.'.concat(#db).concat('.').concat(#collection))")
+	@PreAuthorize("!@authz.isSecured() or #oauth2.hasScope('fdns.object.'.concat(#db).concat('.').concat(#collection).concat('.read'))")
 	@RequestMapping(method = RequestMethod.POST, value = "/{db}/{collection}/count", produces = MediaType.APPLICATION_JSON_VALUE, consumes = MediaType.APPLICATION_JSON_VALUE)
 	@ApiOperation(value = "Count object(s)", notes = "Uses MongoDB's Count method to count object(s) in a collection")
 	@ApiResponses(value = {
@@ -749,7 +749,7 @@ public class ObjectController {
 		}
 	}
 
-	@PreAuthorize("!@authz.isSecured() or #oauth2.hasScope('object.'.concat(#db).concat('.').concat(#collection))")
+	@PreAuthorize("!@authz.isSecured() or #oauth2.hasScope('fdns.object.'.concat(#db).concat('.').concat(#collection).concat('.read'))")
 	@RequestMapping(method = RequestMethod.POST, value = "/{db}/{collection}/distinct/{field}", produces = MediaType.APPLICATION_JSON_VALUE, consumes = MediaType.APPLICATION_JSON_VALUE)
 	@ApiOperation(value = "Get distinct values from a specified field", notes = "Uses MongoDB's distinct method to get the distinct values for a specified field across a single collection")
 	@ApiResponses(value = {

--- a/src/main/java/gov/cdc/foundation/controller/ObjectController.java
+++ b/src/main/java/gov/cdc/foundation/controller/ObjectController.java
@@ -94,9 +94,20 @@ public class ObjectController {
 		}
 	}
 
-
-	@PreAuthorize("!@authz.isSecured() or #oauth2.hasScope('fdns.object.'.concat(#db).concat('.').concat(#collection).concat('.read')) or (#db == 'settings')")
-	@RequestMapping(method = RequestMethod.GET, value = "/{db}/{collection}/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
+	@PreAuthorize(
+		"!@authz.isSecured()"
+		+ " or (#db == 'settings')"
+		+ " or #oauth2.hasScope('fdns.object.'.concat(#db).concat('.').concat(#collection).concat('.read'))"
+		+ " or #oauth2.hasScope('fdns.object.*.'.concat(#collection).concat('.read'))"
+		+ " or #oauth2.hasScope('fdns.object.'.concat(#db).concat('.*').concat('.read'))"
+		+ " or #oauth2.hasScope('fdns.object.*.*.read')" 
+		+ " or #oauth2.hasScope('fdns.object.*.*.*')"
+	)
+	@RequestMapping(
+		method = RequestMethod.GET,
+		value = "/{db}/{collection}/{id}",
+		produces = MediaType.APPLICATION_JSON_VALUE
+	)
 	@ApiOperation(value = "Get object", notes = "Get object")
 	@ApiResponses(value = {
 			@ApiResponse(code = 200, message = "Returns object"),
@@ -106,8 +117,11 @@ public class ObjectController {
 			@ApiResponse(code = 404, message = "Object not found in collection")
 	})
 	@ResponseBody
-	public ResponseEntity<?> getObject(@ApiParam(value = "Database name") @PathVariable(value = "db") String db, @ApiParam(value = "Collection name") @PathVariable(value = "collection") String collection, @ApiParam(value = "Object Id") @PathVariable(value = "id") String id) {
-
+	public ResponseEntity<?> getObject(
+		@ApiParam(value = "Database name") @PathVariable(value = "db") String db,
+		@ApiParam(value = "Collection name") @PathVariable(value = "collection") String collection,
+		@ApiParam(value = "Object Id") @PathVariable(value = "id") String id
+	) {
 		Map<String, Object> log = MessageHelper.initializeLog(MessageHelper.METHOD_GETOBJECT, db, collection);
 
 		ObjectMapper mapper = new ObjectMapper();
@@ -145,8 +159,21 @@ public class ObjectController {
 		}
 	}
 
-	@PreAuthorize("!@authz.isSecured() or #oauth2.hasScope('fdns.object.'.concat(#db).concat('.').concat(#collection).concat('.create')) or (#db == 'settings')")
-	@RequestMapping(method = RequestMethod.POST, value = "/{db}/{collection}", produces = MediaType.APPLICATION_JSON_VALUE, consumes = MediaType.APPLICATION_JSON_VALUE)
+	@PreAuthorize(
+		"!@authz.isSecured()"
+		+ " or (#db == 'settings')"
+		+ " or #oauth2.hasScope('fdns.object.'.concat(#db).concat('.').concat(#collection).concat('.create'))"
+		+ " or #oauth2.hasScope('fdns.object.*.'.concat(#collection).concat('.create'))"
+		+ " or #oauth2.hasScope('fdns.object.'.concat(#db).concat('.*').concat('.create'))"
+		+ " or #oauth2.hasScope('fdns.object.*.*.create')"
+		+ " or #oauth2.hasScope('fdns.object.*.*.*')"
+	)
+	@RequestMapping(
+		method = RequestMethod.POST,
+		value = "/{db}/{collection}",
+		produces = MediaType.APPLICATION_JSON_VALUE,
+		consumes = MediaType.APPLICATION_JSON_VALUE
+	)
 	@ApiOperation(value = "Create object", notes = "Create object")
 	@ApiResponses(value = {
 			@ApiResponse(code = 201, message = "Returns object that was just created"),
@@ -157,8 +184,11 @@ public class ObjectController {
 			@ApiResponse(code = 413, message = "Request payload too large")
 	})
 	@ResponseBody
-	public ResponseEntity<?> createObject(@RequestBody String payload, @ApiParam(value = "Database name") @PathVariable(value = "db", required = true) String db, @ApiParam(value = "Collection name") @PathVariable(value = "collection", required = true) String collection) {
-
+	public ResponseEntity<?> createObject(
+		@RequestBody String payload,
+		@ApiParam(value = "Database name") @PathVariable(value = "db", required = true) String db,
+		@ApiParam(value = "Collection name") @PathVariable(value = "collection", required = true) String collection
+	) {
 		Map<String, Object> log = MessageHelper.initializeLog(MessageHelper.METHOD_CREATEOBJECT, db, collection);
 
 		ObjectMapper mapper = new ObjectMapper();
@@ -176,7 +206,15 @@ public class ObjectController {
 		}
 	}
 
-	@PreAuthorize("!@authz.isSecured() or #oauth2.hasScope('fdns.object.'.concat(#db).concat('.').concat(#collection).concat('.read')) or (#db == 'settings')")
+	@PreAuthorize(
+		"!@authz.isSecured()"
+		+ " or (#db == 'settings')"
+		+ " or #oauth2.hasScope('fdns.object.'.concat(#db).concat('.').concat(#collection).concat('.read'))"
+		+ " or #oauth2.hasScope('fdns.object.*.'.concat(#collection).concat('.read'))"
+		+ " or #oauth2.hasScope('fdns.object.'.concat(#db).concat('.*').concat('.read'))"
+		+ " or #oauth2.hasScope('fdns.object.*.*.read')" 
+		+ " or #oauth2.hasScope('fdns.object.*.*.*')"
+	)
 	@RequestMapping(method = RequestMethod.GET, value = "/{db}/{collection}/", produces = MediaType.APPLICATION_JSON_VALUE)
 	@ApiOperation(value = "Get all objects in a collection", notes = "Get all objects in a collection")
 	@ApiResponses(value = {
@@ -187,8 +225,10 @@ public class ObjectController {
 			@ApiResponse(code = 404, message = "Collection not found in the specified database")
 	})
 	@ResponseBody
-	public ResponseEntity<?> getCollection(@ApiParam(value = "Database name") @PathVariable(value = "db") String db, @ApiParam(value = "Collection name") @PathVariable(value = "collection") String collection) {
-
+	public ResponseEntity<?> getCollection(
+		@ApiParam(value = "Database name") @PathVariable(value = "db") String db,
+		@ApiParam(value = "Collection name") @PathVariable(value = "collection") String collection
+	) {
 		Map<String, Object> log = MessageHelper.initializeLog(MessageHelper.METHOD_GETCOLLECTION, db, collection);
 
 		ObjectMapper mapper = new ObjectMapper();
@@ -217,8 +257,21 @@ public class ObjectController {
 		}
 	}
 
-	@PreAuthorize("!@authz.isSecured() or #oauth2.hasScope('fdns.object.'.concat(#db).concat('.').concat(#collection).concat('.create')) or (#db == 'settings')")
-	@RequestMapping(method = RequestMethod.POST, value = "/multi/{db}/{collection}", produces = MediaType.APPLICATION_JSON_VALUE, consumes = MediaType.APPLICATION_JSON_VALUE)
+	@PreAuthorize(
+		"!@authz.isSecured()"
+		+ " or (#db == 'settings')"
+		+ " or #oauth2.hasScope('fdns.object.'.concat(#db).concat('.').concat(#collection).concat('.create'))"
+		+ " or #oauth2.hasScope('fdns.object.*.'.concat(#collection).concat('.create'))"
+		+ " or #oauth2.hasScope('fdns.object.'.concat(#db).concat('.*').concat('.create'))"
+		+ " or #oauth2.hasScope('fdns.object.*.*.create')" 
+		+ " or #oauth2.hasScope('fdns.object.*.*.*')"
+	)
+	@RequestMapping(
+		method = RequestMethod.POST,
+		value = "/multi/{db}/{collection}",
+		produces = MediaType.APPLICATION_JSON_VALUE,
+		consumes = MediaType.APPLICATION_JSON_VALUE
+	)
 	@ApiOperation(value = "Create a list of objects", notes = "Create a list of objects")
 	@ApiResponses(value = {
 			@ApiResponse(code = 201, message = "Returns ids of created objects"),
@@ -229,8 +282,11 @@ public class ObjectController {
 			@ApiResponse(code = 413, message = "Request payload too large")
 	})
 	@ResponseBody
-	public ResponseEntity<?> createObjects(@ApiParam(value = "Array of JSON objects") @RequestBody String payload, @ApiParam(value = "Database name") @PathVariable(value = "db", required = true) String db, @ApiParam(value = "Collection name") @PathVariable(value = "collection", required = true) String collection) {
-
+	public ResponseEntity<?> createObjects(
+		@ApiParam(value = "Array of JSON objects") @RequestBody String payload,
+		@ApiParam(value = "Database name") @PathVariable(value = "db", required = true) String db,
+		@ApiParam(value = "Collection name") @PathVariable(value = "collection", required = true) String collection
+	) {
 		Map<String, Object> log = MessageHelper.initializeLog(MessageHelper.METHOD_CREATEOBJECTS, db, collection);
 
 		ObjectMapper mapper = new ObjectMapper();
@@ -263,7 +319,14 @@ public class ObjectController {
 		}
 	}
 
-	@PreAuthorize("!@authz.isSecured() or #oauth2.hasScope('fdns.object.'.concat(#db).concat('.').concat(#collection).concat('.create'))")
+	@PreAuthorize(
+		"!@authz.isSecured()"
+		+ " or #oauth2.hasScope('fdns.object.'.concat(#db).concat('.').concat(#collection).concat('.create'))"
+		+ " or #oauth2.hasScope('fdns.object.*.'.concat(#collection).concat('.create'))"
+		+ " or #oauth2.hasScope('fdns.object.'.concat(#db).concat('.*').concat('.create'))"
+		+ " or #oauth2.hasScope('fdns.object.*.*.create')" 
+		+ " or #oauth2.hasScope('fdns.object.*.*.*')"
+	)
 	@RequestMapping(method = RequestMethod.POST, value = "/bulk/{db}/{collection}", produces = MediaType.APPLICATION_JSON_VALUE)
 	@ApiOperation(value = "Bulk import of objects from a CSV file", notes = "Bulk import of objects from a CSV file")
 	@ResponseBody
@@ -275,9 +338,13 @@ public class ObjectController {
 			@ApiResponse(code = 404, message = "Not Found"),
 			@ApiResponse(code = 413, message = "Request payload too large")
 	})
-    //TODO: CSV files do not return 413 if too large
-	public ResponseEntity<?> bulkImport(@ApiParam(value = "CSV file") @RequestParam("csv") MultipartFile csvFile, @ApiParam(value = "Database name") @PathVariable(value = "db", required = true) String db, @ApiParam(value = "Collection name") @PathVariable(value = "collection", required = true) String collection, @ApiParam(value = "CSV format", allowableValues="Default,Excel,MySQL,RFC4180,TDF", defaultValue="Default") @RequestParam(value = "csvFormat", required = true) String csvFormat) {
-
+  // TODO: CSV files do not return 413 if too large
+	public ResponseEntity<?> bulkImport(
+		@ApiParam(value = "CSV file") @RequestParam("csv") MultipartFile csvFile,
+		@ApiParam(value = "Database name") @PathVariable(value = "db", required = true) String db,
+		@ApiParam(value = "Collection name") @PathVariable(value = "collection", required = true) String collection,
+		@ApiParam(value = "CSV format", allowableValues="Default,Excel,MySQL,RFC4180,TDF", defaultValue="Default") @RequestParam(value = "csvFormat", required = true) String csvFormat
+	) {
 		Map<String, Object> log = MessageHelper.initializeLog(MessageHelper.METHOD_BULKIMPORT, db, collection);
 
 		ObjectMapper mapper = new ObjectMapper();
@@ -336,8 +403,21 @@ public class ObjectController {
 		}
 	}
 
-	@PreAuthorize("!@authz.isSecured() or #oauth2.hasScope('fdns.object.'.concat(#db).concat('.').concat(#collection).concat('.create')) or (#db == 'settings')")
-	@RequestMapping(method = RequestMethod.POST, value = "/{db}/{collection}/{id}", produces = MediaType.APPLICATION_JSON_VALUE, consumes = MediaType.APPLICATION_JSON_VALUE)
+	@PreAuthorize(
+		"!@authz.isSecured()"
+		+ " or (#db == 'settings')"
+		+ " or #oauth2.hasScope('fdns.object.'.concat(#db).concat('.').concat(#collection).concat('.create'))"
+		+ " or #oauth2.hasScope('fdns.object.*.'.concat(#collection).concat('.create'))"
+		+ " or #oauth2.hasScope('fdns.object.'.concat(#db).concat('.*').concat('.create'))"
+		+ " or #oauth2.hasScope('fdns.object.*.*.create')"
+		+ " or #oauth2.hasScope('fdns.object.*.*.*')"
+	)
+	@RequestMapping(
+		method = RequestMethod.POST,
+		value = "/{db}/{collection}/{id}",
+		produces = MediaType.APPLICATION_JSON_VALUE,
+		consumes = MediaType.APPLICATION_JSON_VALUE
+	)
 	@ApiOperation(value = "Create object with id", notes = "Create object with id")
 	@ApiResponses(value = {
 			@ApiResponse(code = 201, message = "Returns object that was just created"),
@@ -348,8 +428,12 @@ public class ObjectController {
 			@ApiResponse(code = 413, message = "Request payload too large")
 	})
 	@ResponseBody
-	public ResponseEntity<?> createObjectWithId(@RequestBody String payload, @ApiParam(value = "Database name") @PathVariable(value = "db") String db, @ApiParam(value = "Collection name") @PathVariable(value = "collection") String collection, @ApiParam(value = "Object Id") @PathVariable(value = "id") String id) {
-
+	public ResponseEntity<?> createObjectWithId(
+		@RequestBody String payload,
+		@ApiParam(value = "Database name") @PathVariable(value = "db") String db,
+		@ApiParam(value = "Collection name") @PathVariable(value = "collection") String collection,
+		@ApiParam(value = "Object Id") @PathVariable(value = "id") String id
+	) {
 		Map<String, Object> log = MessageHelper.initializeLog(MessageHelper.METHOD_CREATEOBJECT, db, collection);
 		ObjectMapper mapper = new ObjectMapper();
 
@@ -375,8 +459,21 @@ public class ObjectController {
 		}
 	}
 
-	@PreAuthorize("!@authz.isSecured() or #oauth2.hasScope('fdns.object.'.concat(#db).concat('.').concat(#collection).concat('.update')) or (#db == 'settings')")
-	@RequestMapping(method = RequestMethod.PUT, value = "/{db}/{collection}/{id}", produces = MediaType.APPLICATION_JSON_VALUE, consumes = MediaType.APPLICATION_JSON_VALUE)
+	@PreAuthorize(
+		"!@authz.isSecured()"
+		+ " or (#db == 'settings')"
+		+ " or #oauth2.hasScope('fdns.object.'.concat(#db).concat('.').concat(#collection).concat('.update'))"
+		+ " or #oauth2.hasScope('fdns.object.*.'.concat(#collection).concat('.update'))"
+		+ " or #oauth2.hasScope('fdns.object.'.concat(#db).concat('.*').concat('.update'))"
+		+ " or #oauth2.hasScope('fdns.object.*.*.update')"
+		+ " or #oauth2.hasScope('fdns.object.*.*.*')"
+	)
+	@RequestMapping(
+		method = RequestMethod.PUT,
+		value = "/{db}/{collection}/{id}",
+		produces = MediaType.APPLICATION_JSON_VALUE,
+		consumes = MediaType.APPLICATION_JSON_VALUE
+	)
 	@ApiOperation(value = "Update object", notes = "Update object")
 	@ApiResponses(value = {
 			@ApiResponse(code = 200, message = "Returns object that was just updated"),
@@ -387,8 +484,12 @@ public class ObjectController {
 			@ApiResponse(code = 413, message = "Request payload too large")
 	})
 	@ResponseBody
-	public ResponseEntity<?> updateObject(@RequestBody @ApiParam(value = "Payload") String payload, @ApiParam(value = "Database name") @PathVariable(value = "db") String db, @ApiParam(value = "Collection name") @PathVariable(value = "collection") String collection, @ApiParam(value = "Object Id") @PathVariable(value = "id") String id) {
-
+	public ResponseEntity<?> updateObject(
+		@RequestBody @ApiParam(value = "Payload") String payload,
+		@ApiParam(value = "Database name") @PathVariable(value = "db") String db,
+		@ApiParam(value = "Collection name") @PathVariable(value = "collection") String collection,
+		@ApiParam(value = "Object Id") @PathVariable(value = "id") String id
+	) {
 		Map<String, Object> log = MessageHelper.initializeLog(MessageHelper.METHOD_UPDATEOBJECT, db, collection);
 		ObjectMapper mapper = new ObjectMapper();
 
@@ -432,7 +533,15 @@ public class ObjectController {
 		}
 	}
 
-	@PreAuthorize("!@authz.isSecured() or #oauth2.hasScope('fdns.object.'.concat(#db).concat('.').concat(#collection).concat('.delete')) or (#db == 'settings')")
+	@PreAuthorize(
+		"!@authz.isSecured()"
+		+ " or (#db == 'settings')"
+		+ " or #oauth2.hasScope('fdns.object.'.concat(#db).concat('.').concat(#collection).concat('.delete'))"
+		+ " or #oauth2.hasScope('fdns.object.*.'.concat(#collection).concat('.delete'))"
+		+ " or #oauth2.hasScope('fdns.object.'.concat(#db).concat('.*').concat('.delete'))"
+		+ " or #oauth2.hasScope('fdns.object.*.*.delete')"
+		+ " or #oauth2.hasScope('fdns.object.*.*.*')"
+	)
 	@RequestMapping(method = RequestMethod.DELETE, value = "/{db}/{collection}/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
 	@ApiOperation(value = "Delete object", notes = "Delete object")
 	@ApiResponses(value = {
@@ -443,8 +552,11 @@ public class ObjectController {
                     @ApiResponse(code = 404, message = "Object with this id not found in the collection or collection does not exist")
 				})
 	@ResponseBody
-	public ResponseEntity<?> deleteObject(@ApiParam(value = "Database name") @PathVariable(value = "db") String db, @ApiParam(value = "Collection name") @PathVariable(value = "collection") String collection, @ApiParam(value = "Object Id") @PathVariable(value = "id") String id) {
-
+	public ResponseEntity<?> deleteObject(
+		@ApiParam(value = "Database name") @PathVariable(value = "db") String db,
+		@ApiParam(value = "Collection name") @PathVariable(value = "collection") String collection,
+		@ApiParam(value = "Object Id") @PathVariable(value = "id") String id
+	) {
 		Map<String, Object> log = MessageHelper.initializeLog(MessageHelper.METHOD_DELETEOBJECT, db, collection);
 
 		ObjectMapper mapper = new ObjectMapper();
@@ -488,7 +600,14 @@ public class ObjectController {
 		}
 	}
 
-	@PreAuthorize("!@authz.isSecured() or #oauth2.hasScope('fdns.object.'.concat(#db).concat('.').concat(#collection).concat('.delete'))")
+	@PreAuthorize(
+		"!@authz.isSecured()" 
+		+ " or #oauth2.hasScope('fdns.object.'.concat(#db).concat('.').concat(#collection).concat('.delete'))"
+		+ " or #oauth2.hasScope('fdns.object.*.'.concat(#collection).concat('.delete'))"
+		+ " or #oauth2.hasScope('fdns.object.'.concat(#db).concat('.*').concat('.delete'))"
+		+ " or #oauth2.hasScope('fdns.object.*.*.delete')"
+		+ " or #oauth2.hasScope('fdns.object.*.*.*')"
+	)
 	@RequestMapping(method = RequestMethod.DELETE, value = "/{db}/{collection}", produces = MediaType.APPLICATION_JSON_VALUE)
 	@ApiOperation(value = "Delete collection", notes = "Delete collection")
 	@ApiResponses(value = {
@@ -499,8 +618,10 @@ public class ObjectController {
 			@ApiResponse(code = 404, message = "Collection not found in database")
 	})
 	@ResponseBody
-	public ResponseEntity<?> deleteCollection(@ApiParam(value = "Database name") @PathVariable(value = "db") String db, @ApiParam(value = "Collection name") @PathVariable(value = "collection") String collection) {
-
+	public ResponseEntity<?> deleteCollection(
+		@ApiParam(value = "Database name") @PathVariable(value = "db") String db,
+		@ApiParam(value = "Collection name") @PathVariable(value = "collection") String collection
+	) {
 		Map<String, Object> log = MessageHelper.initializeLog(MessageHelper.METHOD_DELETECOLLECTION, db, collection);
 		ObjectMapper mapper = new ObjectMapper();
 
@@ -533,9 +654,23 @@ public class ObjectController {
 		}
 	}
 
-	@PreAuthorize("!@authz.isSecured() or #oauth2.hasScope('fdns.object.'.concat(#db).concat('.').concat(#collection).concat('.read'))")
-	@RequestMapping(method = RequestMethod.GET, value = "/{db}/{collection}/search", produces = MediaType.APPLICATION_JSON_VALUE)
-	@ApiOperation(value = "Search object(s) using query parameters", notes = "Search object(s) in a specific collection using URL parameters instead of POST payloads (as FIND does)")
+	@PreAuthorize(
+		"!@authz.isSecured()"
+		+ " or #oauth2.hasScope('fdns.object.'.concat(#db).concat('.').concat(#collection).concat('.read'))"
+		+ " or #oauth2.hasScope('fdns.object.*.'.concat(#collection).concat('.read'))"
+		+ " or #oauth2.hasScope('fdns.object.'.concat(#db).concat('.*').concat('.read'))"
+		+ " or #oauth2.hasScope('fdns.object.*.*.read')"
+		+ " or #oauth2.hasScope('fdns.object.*.*.*')"
+	)
+	@RequestMapping(
+		method = RequestMethod.GET,
+		value = "/{db}/{collection}/search",
+		produces = MediaType.APPLICATION_JSON_VALUE
+	)
+	@ApiOperation(
+		value = "Search object(s) using query parameters",
+		notes = "Search object(s) in a specific collection using URL parameters instead of POST payloads (as FIND does)"
+	)
 	@ApiResponses(value = {
 			@ApiResponse(code = 200, message = "Returns success boolean"),
 			@ApiResponse(code = 400, message = "Route parameters or json payload contain invalid data"),
@@ -574,8 +709,20 @@ public class ObjectController {
 		}
 	}
 
-	@PreAuthorize("!@authz.isSecured() or #oauth2.hasScope('fdns.object.'.concat(#db).concat('.').concat(#collection).concat('.read'))")
-	@RequestMapping(method = RequestMethod.POST, value = "/{db}/{collection}/find", produces = MediaType.APPLICATION_JSON_VALUE, consumes = MediaType.APPLICATION_JSON_VALUE)
+	@PreAuthorize(
+		"!@authz.isSecured()" 
+		+ " or #oauth2.hasScope('fdns.object.'.concat(#db).concat('.').concat(#collection).concat('.read'))"
+		+ " or #oauth2.hasScope('fdns.object.*.'.concat(#collection).concat('.read'))"
+		+ " or #oauth2.hasScope('fdns.object.'.concat(#db).concat('.*').concat('.read'))"
+		+ " or #oauth2.hasScope('fdns.object.*.*.read')"
+		+ " or #oauth2.hasScope('fdns.object.*.*.*')"
+	)
+	@RequestMapping(
+		method = RequestMethod.POST,
+		value = "/{db}/{collection}/find",
+		produces = MediaType.APPLICATION_JSON_VALUE,
+		consumes = MediaType.APPLICATION_JSON_VALUE
+	)
 	@ApiOperation(value = "Find object(s)", notes = "Uses MongoDB's find method to  object(s)")
 	@ApiResponses(value = {
 			@ApiResponse(code = 200, message = "Returns all objects in specified collection"),
@@ -618,7 +765,14 @@ public class ObjectController {
 		}
 	}
 
-	private JSONObject executeQuery(MongoCollection<Document> coll, Document query, int from, int size, String sort, int order) throws ServiceException {
+	private JSONObject executeQuery(
+		MongoCollection<Document> coll,
+		Document query,
+		int from,
+		int size,
+		String sort,
+		int order
+	) throws ServiceException {
 		JSONArray results = new JSONArray();
 		JSONObject json = new JSONObject();
 
@@ -646,8 +800,20 @@ public class ObjectController {
 		return json;
 	}
 
-	@PreAuthorize("!@authz.isSecured() or #oauth2.hasScope('fdns.object.'.concat(#db).concat('.').concat(#collection).concat('.read'))")
-	@RequestMapping(method = RequestMethod.POST, value = "/{db}/{collection}/aggregate", produces = MediaType.APPLICATION_JSON_VALUE, consumes = MediaType.APPLICATION_JSON_VALUE)
+	@PreAuthorize(
+		"!@authz.isSecured()"
+		+ " or #oauth2.hasScope('fdns.object.'.concat(#db).concat('.').concat(#collection).concat('.read'))"
+		+ " or #oauth2.hasScope('fdns.object.*.'.concat(#collection).concat('.read'))"
+		+ " or #oauth2.hasScope('fdns.object.'.concat(#db).concat('.*').concat('.read'))"
+		+ " or #oauth2.hasScope('fdns.object.*.*.read')"
+		+ " or #oauth2.hasScope('fdns.object.*.*.*')"
+	)
+	@RequestMapping(
+		method = RequestMethod.POST,
+		value = "/{db}/{collection}/aggregate",
+		produces = MediaType.APPLICATION_JSON_VALUE,
+		consumes = MediaType.APPLICATION_JSON_VALUE
+	)
 	@ApiOperation(value = "Mongo Aggregate", notes = "Uses MongoDB's Aggregate method to calculate aggregate values in a collection")
 	@ApiResponses(value = {
 			@ApiResponse(code = 200, message = "Returns all objects in specified collection"),
@@ -658,8 +824,11 @@ public class ObjectController {
 			@ApiResponse(code = 413, message = "Request payload too large")
 	})
 	@ResponseBody
-	public ResponseEntity<?> aggregate(@RequestBody String payload, @ApiParam(value = "Database name") @PathVariable(value = "db") String db, @ApiParam(value = "Collection name") @PathVariable(value = "collection") String collection) {
-
+	public ResponseEntity<?> aggregate(
+		@RequestBody String payload,
+		@ApiParam(value = "Database name") @PathVariable(value = "db") String db,
+		@ApiParam(value = "Collection name") @PathVariable(value = "collection") String collection
+	) {
 		Map<String, Object> log = MessageHelper.initializeLog(MessageHelper.METHOD_AGGREGATE, db, collection);
 
 		ObjectMapper mapper = new ObjectMapper();
@@ -703,8 +872,20 @@ public class ObjectController {
 		}
 	}
 
-	@PreAuthorize("!@authz.isSecured() or #oauth2.hasScope('fdns.object.'.concat(#db).concat('.').concat(#collection).concat('.read'))")
-	@RequestMapping(method = RequestMethod.POST, value = "/{db}/{collection}/count", produces = MediaType.APPLICATION_JSON_VALUE, consumes = MediaType.APPLICATION_JSON_VALUE)
+	@PreAuthorize(
+		"!@authz.isSecured()"
+		+ " or #oauth2.hasScope('fdns.object.'.concat(#db).concat('.').concat(#collection).concat('.read'))"
+		+ " or #oauth2.hasScope('fdns.object.*.'.concat(#collection).concat('.read'))"
+		+ " or #oauth2.hasScope('fdns.object.'.concat(#db).concat('.*').concat('.read'))"
+		+ " or #oauth2.hasScope('fdns.object.*.*.read')"
+		+ " or #oauth2.hasScope('fdns.object.*.*.*')"
+	)
+	@RequestMapping(
+		method = RequestMethod.POST,
+		value = "/{db}/{collection}/count",
+		produces = MediaType.APPLICATION_JSON_VALUE,
+		consumes = MediaType.APPLICATION_JSON_VALUE
+	)
 	@ApiOperation(value = "Count object(s)", notes = "Uses MongoDB's Count method to count object(s) in a collection")
 	@ApiResponses(value = {
 			@ApiResponse(code = 200, message = "Returns number of objects in collection"),
@@ -715,8 +896,11 @@ public class ObjectController {
 			@ApiResponse(code = 413, message = "Request payload too large")
 	})
 	@ResponseBody
-	public ResponseEntity<?> count(@RequestBody String payload, @ApiParam(value = "Database name") @PathVariable(value = "db") String db, @ApiParam(value = "Collection name") @PathVariable(value = "collection") String collection) {
-
+	public ResponseEntity<?> count(
+		@RequestBody String payload,
+		@ApiParam(value = "Database name") @PathVariable(value = "db") String db,
+		@ApiParam(value = "Collection name") @PathVariable(value = "collection") String collection
+	) {
 		Map<String, Object> log = MessageHelper.initializeLog(MessageHelper.METHOD_COUNT, db, collection);
 
 		ObjectMapper mapper = new ObjectMapper();
@@ -749,9 +933,24 @@ public class ObjectController {
 		}
 	}
 
-	@PreAuthorize("!@authz.isSecured() or #oauth2.hasScope('fdns.object.'.concat(#db).concat('.').concat(#collection).concat('.read'))")
-	@RequestMapping(method = RequestMethod.POST, value = "/{db}/{collection}/distinct/{field}", produces = MediaType.APPLICATION_JSON_VALUE, consumes = MediaType.APPLICATION_JSON_VALUE)
-	@ApiOperation(value = "Get distinct values from a specified field", notes = "Uses MongoDB's distinct method to get the distinct values for a specified field across a single collection")
+	@PreAuthorize(
+		"!@authz.isSecured()"
+		+ " or #oauth2.hasScope('fdns.object.'.concat(#db).concat('.').concat(#collection).concat('.read'))"
+		+ " or #oauth2.hasScope('fdns.object.*.'.concat(#collection).concat('.read'))"
+		+ " or #oauth2.hasScope('fdns.object.'.concat(#db).concat('.*').concat('.read'))"
+		+ " or #oauth2.hasScope('fdns.object.*.*.read')"
+		+ " or #oauth2.hasScope('fdns.object.*.*.*')"
+	)
+	@RequestMapping(
+		method = RequestMethod.POST,
+		value = "/{db}/{collection}/distinct/{field}",
+		produces = MediaType.APPLICATION_JSON_VALUE,
+		consumes = MediaType.APPLICATION_JSON_VALUE
+	)
+	@ApiOperation(
+		value = "Get distinct values from a specified field",
+		notes = "Uses MongoDB's distinct method to get the distinct values for a specified field across a single collection"
+	)
 	@ApiResponses(value = {
 			@ApiResponse(code = 200, message = "Returns list of distinct values"),
 			@ApiResponse(code = 400, message = "Route parameters or json payload contain invalid data"),
@@ -761,8 +960,12 @@ public class ObjectController {
 			@ApiResponse(code = 413, message = "Request entity too large")
 	})
 	@ResponseBody
-	public ResponseEntity<?> distinct(@RequestBody String payload, @ApiParam(value = "Database name") @PathVariable(value = "db") String db, @ApiParam(value = "Collection name") @PathVariable(value = "collection") String collection, @ApiParam(value = "Field name") @PathVariable(value = "field") String field) {
-
+	public ResponseEntity<?> distinct(
+		@RequestBody String payload,
+		@ApiParam(value = "Database name") @PathVariable(value = "db") String db,
+		@ApiParam(value = "Collection name") @PathVariable(value = "collection") String collection,
+		@ApiParam(value = "Field name") @PathVariable(value = "field") String field
+	) {
 		Map<String, Object> log = MessageHelper.initializeLog(MessageHelper.METHOD_DISTINCT, db, collection);
 		ObjectMapper mapper = new ObjectMapper();
 

--- a/src/main/java/gov/cdc/foundation/security/OAuth2Configuration.java
+++ b/src/main/java/gov/cdc/foundation/security/OAuth2Configuration.java
@@ -35,7 +35,7 @@ public class OAuth2Configuration extends ResourceServerConfigurerAdapter {
 				.authorizeRequests()
 				.antMatchers(HttpMethod.OPTIONS).permitAll()
 				.antMatchers("/api/1.0/").permitAll()
-				.antMatchers(protectedURIs).access("#oauth2.hasScope('object')")
+				.antMatchers(protectedURIs).access("#oauth2.hasScope('fdns.object')")
 				.anyRequest().permitAll();
 		else
 			http

--- a/src/test/fdns-ms-object - ObjectApplication.launch
+++ b/src/test/fdns-ms-object - ObjectApplication.launch
@@ -33,6 +33,7 @@
 <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Djava.security.egd=file:/dev/./urandom"/>
 <stringAttribute key="process_factory_id" value="org.springframework.ide.eclipse.boot.launch.process.BootProcessFactory"/>
 <booleanAttribute key="spring.boot.ansi.console" value="false"/>
+<stringAttribute key="spring.boot.app.properties" value=""/>
 <booleanAttribute key="spring.boot.dash.hidden" value="false"/>
 <booleanAttribute key="spring.boot.debug.enable" value="false"/>
 <booleanAttribute key="spring.boot.fast.startup" value="true"/>

--- a/src/test/java/gov/cdc/foundation/OAuth2Test.java
+++ b/src/test/java/gov/cdc/foundation/OAuth2Test.java
@@ -11,6 +11,13 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.junit4.SpringRunner;
+import gov.cdc.helper.RequestHelper;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.boot.web.server.LocalServerPort;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(
@@ -24,19 +31,23 @@ import org.springframework.test.context.junit4.SpringRunner;
 					"mongo.username=",
 					"mongo.password=",
 					"immutable=",
-					"proxy.hostname=localhost",
-					"security.oauth2.resource.user-info-uri=",
-					"security.oauth2.protected=/**",
-					"security.oauth2.client.client-id=",
-					"security.oauth2.client.client-secret=",
+					"proxy.hostname=",
+					"security.oauth2.resource.user-info-uri=http://fdns-ms-stubbing:3002/oauth2/token/introspect",
+					"security.oauth2.protected=/api/1.0/**",
+					"security.oauth2.client.client-id=test",
+					"security.oauth2.client.client-secret=testsecret",
 					"ssl.verifying.disable=false"
 				})
 @AutoConfigureMockMvc
 public class OAuth2Test {
 
+	@LocalServerPort
+  private int port;
+
 	@Autowired
 	private TestRestTemplate restTemplate;
 	private String baseUrlPath = "/api/1.0/";
+	private String localBasePath = "http://localhost:";
 
 	@Test
 	public void indexPage() {
@@ -45,9 +56,42 @@ public class OAuth2Test {
 	}
 
 	@Test
-	public void dbPage() {
-		ResponseEntity<String> response = this.restTemplate.getForEntity(baseUrlPath + "db/collection/id", String.class);
+	public void testUnauthenticated() {
+		ResponseEntity<String> response = this.restTemplate.getForEntity(baseUrlPath + "mydb/mycollection", String.class);
 		assertThat(response.getStatusCodeValue()).isEqualTo(401);
 	}
-	
+
+	@Test
+	public void testAthenticatedSpecific() {
+		setScope("fdns.object fdns.object.mydb.mycollection.create");
+		
+		ResponseEntity<String> response = RequestHelper.getInstance("Bearer testtoken")
+				.executePost(
+					localBasePath + port + baseUrlPath + "mydb/mycollection", 
+					"{ \"foo\": \"bar\"}",
+					MediaType.APPLICATION_JSON
+				);
+
+		assertThat(response.getStatusCodeValue()).isEqualTo(201);
+	}
+
+	@Test
+	public void testAthenticatedWildcard() {
+		setScope("fdns.object fdns.object.*.*.*");
+		
+		ResponseEntity<String> response = RequestHelper.getInstance("Bearer testtoken")
+				.executePost(
+					localBasePath + port + baseUrlPath + "mydb/mycollection", 
+					"{ \"foo\": \"bar\"}",
+					MediaType.APPLICATION_JSON
+				);
+
+		assertThat(response.getStatusCodeValue()).isEqualTo(201);
+	}
+
+	private void setScope(String scope) {
+		MultiValueMap<String, String> data = new LinkedMultiValueMap<>();
+		data.add("scope", scope);
+		RequestHelper.getInstance().executePost("http://fdns-ms-stubbing:3002/oauth2/mock", data);
+	}
 }

--- a/src/test/java/gov/cdc/foundation/ObjectApplicationErrorTests.java
+++ b/src/test/java/gov/cdc/foundation/ObjectApplicationErrorTests.java
@@ -35,7 +35,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 					"mongo.username=",
 					"mongo.password=",
 					"immutable=",
-					"proxy.hostname=localhost",
+					"proxy.hostname=",
 					"security.oauth2.resource.user-info-uri=",
 					"security.oauth2.protected=",
 					"security.oauth2.client.client-id=",

--- a/src/test/java/gov/cdc/foundation/ObjectApplicationTests.java
+++ b/src/test/java/gov/cdc/foundation/ObjectApplicationTests.java
@@ -48,7 +48,7 @@ import javax.servlet.http.HttpServletResponse;
 					"mongo.username=",
 					"mongo.password=",
 					"immutable=",
-					"proxy.hostname=localhost",
+					"proxy.hostname=",
 					"security.oauth2.resource.user-info-uri=",
 					"security.oauth2.protected=",
 					"security.oauth2.client.client-id=",


### PR DESCRIPTION
This pull request proposes a few changes:

- Changing the scopes to fall under a `fdns.*` namespace
- Adds support for CRUD operations (create, read, update and delete) and appends it at the end of the scope
- Adds support for wildcard scopes
- Adds the new https://github.com/CDCgov/fdns-ms-stubbing service for unit testing and tests OAuth 2.0 functionality